### PR TITLE
Preventing linux package updating and broke booting

### DIFF
--- a/arkdep-build.d/arkanelinux/pacman.conf
+++ b/arkdep-build.d/arkanelinux/pacman.conf
@@ -22,7 +22,7 @@ HoldPkg     = pacman glibc
 Architecture = auto
 
 # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
-#IgnorePkg   =
+IgnorePkg    = linux linux-headers
 #IgnoreGroup =
 
 #NoUpgrade   =

--- a/arkdep-build.d/depends/arkanelinux-generic/package.list
+++ b/arkdep-build.d/depends/arkanelinux-generic/package.list
@@ -16,6 +16,7 @@ git
 glibc-locales
 libnss-extrausers
 libva-mesa-driver
+linux-headers
 man-db
 mesa
 mesa-vdpau

--- a/arkdep-build.d/test-arkanelinux-kde/pacman.conf
+++ b/arkdep-build.d/test-arkanelinux-kde/pacman.conf
@@ -22,7 +22,7 @@ HoldPkg     = pacman glibc
 Architecture = auto
 
 # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
-#IgnorePkg   =
+IgnorePkg    = linux linux-headers
 #IgnoreGroup =
 
 #NoUpgrade   =

--- a/arkdep-build.d/test-arkanelinux-pantheon/pacman.conf
+++ b/arkdep-build.d/test-arkanelinux-pantheon/pacman.conf
@@ -22,7 +22,7 @@ HoldPkg     = pacman glibc
 Architecture = auto
 
 # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
-#IgnorePkg   =
+IgnorePkg    = linux linux-headers
 #IgnoreGroup =
 
 #NoUpgrade   =


### PR DESCRIPTION
I remember wanting to install VirtualBox and due to no old deployments completely broke the startup due to linux updates. I'm not sure, but I think this change fixes it by disallowing linux and linux-headers package updates and adding the linux-headers package so it doesn't install or update linux to install dkms modules. I haven't touched znver4 as I don't know if CachyOS uses kernel packages like Arch Linux