### PR TITLE
[arkanelinux] Some package.list corrections

### DIFF
--- a/arkdep-build.d/arkanelinux/package.list
+++ b/arkdep-build.d/arkanelinux/package.list
@@ -6,6 +6,7 @@ gnome-console
 gnome-control-center
 gnome-disk-utility
 gnome-initial-setup
+gnome-menus
 gnome-shell
 gnome-software
 gnome-system-monitor

--- a/arkdep-build.d/arkanelinux/package.list
+++ b/arkdep-build.d/arkanelinux/package.list
@@ -6,7 +6,6 @@ gnome-console
 gnome-control-center
 gnome-disk-utility
 gnome-initial-setup
-gnome-menus
 gnome-shell
 gnome-software
 gnome-system-monitor
@@ -22,14 +21,13 @@ bluez-utils
 cups
 cups-pdf
 flatpak
-fuse
+fuse3
 fwupd
 gst-plugin-pipewire
 gst-plugins-base
 gst-plugins-good
 gvfs
 gvfs-afc
-gvfs-dnssd
 gvfs-dnssd
 gvfs-goa
 gvfs-gphoto2
@@ -61,7 +59,6 @@ xdg-utils
 arkane-application-cleaner
 arkane-flatpak-init
 arkane-wallpapers
-libnss-extrausers
 
 # Community requested
 v4l-utils

--- a/arkdep-build.d/depends/arkanelinux-generic/package.list
+++ b/arkdep-build.d/depends/arkanelinux-generic/package.list
@@ -16,11 +16,9 @@ fakeroot
 git
 glibc-locales
 libnss-extrausers
-libva-mesa-driver
 linux-headers
 man-db
 mesa
-mesa-vdpau
 neovim
 networkmanager
 openssh


### PR DESCRIPTION
I've just started building my own deployments with arkdep-build, so I thought I'd provide some feedback/corrections regarding the default list of packages.

The changes are:

**arkanelinux:**
- Remove gnome-menus - acording to its Gitlab page they're only for the Gnome classic session which Arkanelinux doesn't ship.
- Rename fuse to fuse3 - there is no fuse package, only fuse2 or fuse3.
- Remove duplicate gvfs-dnssd
- Remove libnss-extrausers - it's already in arkanelinux-generic package.list.

 **arkanelinux-generic:**
- Remove libva-mesa-driver and mesa-vdpau - these 2 packages don't exist anymore.

Also, I didn't change that, but I noticed that you've added Orca to arkanelinux-generic package.list. Since it's a Gnome app, wouldn't it make sense to add it only to arkanelinux?


On a different note, currently the process of building your own deployments and then locally deploying it is: creating a ~3.5gb .img image, then compressing it into a ~1.5gb .zst archive which is then uncompressed again during the deployment process. After that I have to manually delete the 3.5gb .img.
I understand that compressing into .zst is necessary to make deployment downloads smaller/faster, but for locally built deployments that seems a bit redundant imo.
So I'd like to ask if it would be possible to make the deployment process directly use the .img image? If you're frequently building deployments and locally deploying them, it would be less wear on the SSD.